### PR TITLE
Doc Rust-Sphinx Workflow fix

### DIFF
--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin
-        pip install ${{inputs.py_interface_folder}}/
-        python -m pip install -r ${{inputs.py_docs_folder}}/requirements.txt
+        pip install ${{inputs.py_interface_folder}}/[docs]
     - name: build
       run: |
         cd ${{inputs.py_docs_folder}}


### PR DESCRIPTION
Modifies the rust-sphinx doc reusable to comply with the new pyproject.toml use