### PR TITLE
Removing if statement from publishing documentation workflows

### DIFF
--- a/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
@@ -42,7 +42,6 @@ jobs:
         cd ../../
     - name: publish
       uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{inputs.docs_folder}}/_build/html/

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -48,7 +48,6 @@ jobs:
         cd ../../
     - name: publish
       uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{inputs.py_docs_folder}}/_build/html/

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin
-        pip install ${{inputs.py_interface_folder}}/
-        python -m pip install -r ${{inputs.py_docs_folder}}/requirements.txt
+        pip install ${{inputs.py_interface_folder}}/[docs]
     - name: build
       run: |
         cd ${{inputs.py_docs_folder}}


### PR DESCRIPTION
The `if` statements in the publishing workflows are (counter-intuitively) preventing the documentation from being published. The condition only evaluates to `True` if the branch the action is started on is `main`, but when a new release is created, it gets it's own tagged branch, so the condition evaluates to `False` every time. We can see this is the issue because while the `publish` step of the workflow is skipped with a tagged version, manually triggering the workflow does not skip the `publish` step.