### PR TITLE
Conditioned Python 3.12

### DIFF
--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       py_interface_folder:
@@ -30,6 +35,11 @@ on:
         type: boolean
       universal2:
         description: "Build python wheels with universal2 flag"
+        required: false
+        default: true
+        type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
         required: false
         default: true
         type: boolean
@@ -48,6 +58,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -114,7 +114,6 @@ jobs:
 
   test_maturin_builds_macos:
     name: maturin_check_macos-${{ matrix.python.interpreter }}
-    continue-on-error: true   # IMPORTANT: this will show the green "successful job" tick even when it failed
     if: ${{inputs.macos}}
     runs-on: "macOS-latest"
     strategy:

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       py_interface_folder:
@@ -43,6 +48,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   test_maturin_builds_linux:
@@ -57,6 +67,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2.0.0
@@ -91,6 +102,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2.0.0
@@ -125,6 +137,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2.0.0

--- a/.github/workflows/reusable_linting_pure_python.yml
+++ b/.github/workflows/reusable_linting_pure_python.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install ${{inputs.python_folder}}/[dev]

--- a/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -31,7 +31,7 @@ jobs:
     # - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       python_folder:
@@ -41,6 +46,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
 
@@ -56,6 +66,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -88,6 +99,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -120,6 +132,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -22,6 +22,11 @@ on:
         description: "Name of the pure rust package"
         required: true
         type: string
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       windows:
@@ -43,6 +48,11 @@ on:
         description: "Name of the pure rust package"
         required: true
         type: string
+      python_3_12:
+        description: "Run unittest on Python 3.12"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
 
@@ -59,6 +69,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2
@@ -88,6 +99,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2
@@ -115,6 +127,7 @@ jobs:
             {py: '3.11', interpreter: "python3.11"},
             {py: '3.12', interpreter: "python3.12"},
         ]
+    if: ${{ matrix.python.py != '3.12' || inputs.python_3_12 }}
     steps:
       - uses: actions/checkout@v3
       # - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Conditions the Python 3.12 based on a new input.
Defaults back to 3.11 on jobs where the python version is not relevant, as to not stop them in case some packages dependencies do not support 3.12 yet.