### PR TITLE
Missing Python 3.12 setuptools 

### DIFF
--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pytest numpy twine
-          python -m pip install maturin
+          python -m pip install maturin setuptools
       - name: macos wheels
         if: ${{ inputs.universal2 == false }}
         run: |

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -104,7 +104,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          pip install maturin pytest numpy
+          pip install maturin pytest numpy setuptools
           pip install ${{inputs.py_interface_folder}}/
       - name: test
         if: ${{inputs.has_python_tests}}
@@ -161,7 +161,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          pip install maturin pytest numpy
+          pip install maturin pytest numpy setuptools
           pip install ${{inputs.py_interface_folder}}/
       - name: test
         if: ${{inputs.has_python_tests}}
@@ -220,7 +220,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          pip install maturin pytest numpy
+          pip install maturin pytest numpy setuptools
           pip install ${{inputs.py_interface_folder}}/
       - name: test
         if: ${{inputs.has_python_tests}}

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -96,6 +96,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
+          pip install setuptools
           pip install ${{inputs.python_folder}}/[tests]
       - name: Test with coverage pytest
         if: ${{inputs.test_code_coverage}}
@@ -150,6 +151,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
+          pip install setuptools
           pip install ${{inputs.python_folder}}/[tests]
       - name: Test with coverage pytest
         if: ${{inputs.test_code_coverage}}
@@ -204,6 +206,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
+          pip install setuptools
           pip install ${{inputs.python_folder}}/[tests]
       - name: Test with coverage pytest
         if: ${{inputs.test_code_coverage}}


### PR DESCRIPTION
As explained in here https://github.com/python/cpython/issues/95299 Python 3.12, when installed via `venv`, does not automatically install `setuptools` anymore, so we need to tell the runners to do it.

Part of the important deprecations in here https://docs.python.org/3/whatsnew/3.12.html