### PR TITLE
`macos-13` Pin

### DIFF
--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -48,7 +48,7 @@ jobs:
 
   build_maturin_builds_macos:
     name: maturin_build-macos-${{ matrix.python.interpreter }}
-    runs-on: 'macOS-latest'
+    runs-on: 'macOS-13'
     strategy:
       matrix:
         python: [

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -171,7 +171,7 @@ jobs:
   test_maturin_builds_macos:
     name: maturin_check_macos-${{ matrix.python.interpreter }}
     if: ${{ inputs.macos }}
-    runs-on: "macOS-latest"
+    runs-on: "macOS-13"
     strategy:
       matrix:
         python: [

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -166,7 +166,7 @@ jobs:
 
   test_python_macos:
     name: test_python_macos-${{ matrix.python.interpreter }}
-    runs-on: "macOS-latest"
+    runs-on: "macOS-13"
     strategy:
       matrix:
         python: [

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -106,7 +106,7 @@ jobs:
   unittests_check_macos:
     if: ${{ inputs.macos }}
     name: unittests-macos-${{ matrix.python.interpreter }}
-    runs-on: "macOS-latest"
+    runs-on: "macOS-13"
     strategy:
       matrix:
         python: [


### PR DESCRIPTION
Necessary because of missing support of Python <=3.10 when using `macos-latest`.
https://github.com/actions/setup-python/issues/850