### PR TITLE
Separate Build Folders

### DIFF
--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -60,8 +60,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: wheels
+          name: linux_wheels
+          path: linux_wheels
 
   build_maturin_builds_linux_arm:
     name: maturin_build-linux-arm
@@ -91,8 +91,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels_arm
-          path: wheels
+          name: linux_arm_wheels
+          path: linux_wheels
 
   build_maturin_src_builds_linux:
     name: maturin_build-src
@@ -117,8 +117,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: wheels
+          name: linux_sdist
+          path: linux_wheels
 
   deploy:
     if: ${{inputs.deploy}}
@@ -130,7 +130,10 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v3
       with:
-        name: wheels
+        name: linux_wheels
+    - uses: actions/download-artifact@v3
+      with:
+        name: linux_sdist
     - name: Publish
       env:
         TWINE_USERNAME: __token__
@@ -150,7 +153,7 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v3
       with:
-        name: wheels_arm
+        name: linux_arm_wheels
     - name: Publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: linux_wheels
-          path: linux_wheels
+          path: wheels
 
   build_maturin_builds_linux_arm:
     name: maturin_build-linux-arm
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: linux_arm_wheels
-          path: linux_wheels
+          path: wheels
 
   build_maturin_src_builds_linux:
     name: maturin_build-src
@@ -118,7 +118,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: linux_sdist
-          path: linux_wheels
+          path: wheels
 
   deploy:
     if: ${{inputs.deploy}}

--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: macos_wheels
-          path: macos_wheels
+          path: wheels
     
   build_maturin_builds_macos_py312:
     if: ${{ inputs.python_3_12 }}
@@ -120,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: macos_wheels
-          path: macos_wheels
+          path: wheels
 
   deploy:
     if: ${{inputs.deploy}}

--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -85,8 +85,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: wheels
+          name: macos_wheels
+          path: macos_wheels
     
   build_maturin_builds_macos_py312:
     if: ${{ inputs.python_3_12 }}
@@ -119,8 +119,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: wheels
+          name: macos_wheels
+          path: macos_wheels
 
   deploy:
     if: ${{inputs.deploy}}
@@ -132,7 +132,7 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v3
       with:
-        name: wheels
+        name: macos_wheels
     - name: Publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows_wheels
-          path: windows_wheels
+          path: wheels
 
   deploy:
     if: ${{inputs.deploy}}

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -46,8 +46,8 @@ jobs:
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:
-          name: wheels
-          path: wheels
+          name: windows_wheels
+          path: windows_wheels
 
   deploy:
     if: ${{inputs.deploy}}
@@ -59,7 +59,7 @@ jobs:
         python-version: "3.12"
     - uses: actions/download-artifact@v3
       with:
-        name: wheels
+        name: windows_wheels
     - name: Publish
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
This avoids automatically deploying other workflows' wheels.