### PR TITLE
Unittesting Features Support

### DIFF
--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -83,8 +83,8 @@ on:
         required: false
         # default: ""
         type: string
-env:
-  DEFAULT_FEATURES_VALUE: "${{ inputs.features || 'json_schema' }}"
+# env:
+#   DEFAULT_FEATURES_VALUE: "${{ inputs.features || 'json_schema' }}"
 
 jobs:
   unittests_check_windows:
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || 'json_schema' }}""
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || 'json_schema' }}"
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -40,6 +40,7 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
+        default: ""
         type: string
   workflow_call:
     inputs:
@@ -80,6 +81,7 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
+        default: ""
         type: string
 env:
   DEFAULT_FEATURES_VALUE: ${{ inputs.features || ' ' }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -109,7 +109,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}
@@ -128,7 +128,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_windows_py3_9:
     if: ${{ inputs.windows && inputs.python_3_9 }}
@@ -147,7 +147,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_windows_py3_12:
     if: ${{ inputs.windows && inputs.python_3_12 }}
@@ -166,7 +166,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_macos:
     if: ${{ inputs.macos }}
@@ -194,7 +194,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_macos_py3_8:
     if: ${{ inputs.macos && inputs.python_3_8 }}
@@ -213,7 +213,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_macos_py3_9:
     if: ${{ inputs.macos && inputs.python_3_9 }}
@@ -232,7 +232,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_macos_py3_12:
     if: ${{ inputs.macos && inputs.python_3_12 }}
@@ -251,7 +251,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_linux:
     name: unittests-linux-${{ matrix.python.interpreter }}
@@ -279,7 +279,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_8:
@@ -299,7 +299,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_9:
@@ -319,7 +319,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_12:
@@ -339,7 +339,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
           cargo fmt --all -- --check
 
   doctest_check:
@@ -355,7 +355,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           default: true
       - run: |
-          cargo test --doc --package=${{inputs.rust_package_name}} --features ${{ inputs.features }}
+          cargo test --doc --package=${{inputs.rust_package_name}} --features ${{ inputs.features || '' }}
 
   code_coverage_roqoqo:
     if: ${{inputs.test_code_coverage}}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features "json_schema"
+          cargo test --workspace --no-default-features --locked --features json_schema
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -40,7 +40,6 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
-        default: ""
         type: string
   workflow_call:
     inputs:
@@ -81,7 +80,6 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
-        default: ""
         type: string
 
 jobs:

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE || 'json_schema' }}
+          cargo test --workspace --no-default-features --locked --features "${{ env.DEFAULT_FEATURES_VALUE || 'json_schema' }}"
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: true
         type: boolean
+      features:
+        description: "Additional features to be enabled for the Rust package"
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       windows:
@@ -73,6 +78,11 @@ on:
         required: false
         default: true
         type: boolean
+      features:
+        description: "Additional features to be enabled for the Rust package"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   unittests_check_windows:
@@ -101,7 +111,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}
@@ -120,7 +130,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_windows_py3_9:
     if: ${{ inputs.windows && inputs.python_3_9 }}
@@ -139,7 +149,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_windows_py3_12:
     if: ${{ inputs.windows && inputs.python_3_12 }}
@@ -158,7 +168,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_macos:
     if: ${{ inputs.macos }}
@@ -186,7 +196,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_macos_py3_8:
     if: ${{ inputs.macos && inputs.python_3_8 }}
@@ -205,7 +215,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_macos_py3_9:
     if: ${{ inputs.macos && inputs.python_3_9 }}
@@ -224,7 +234,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_macos_py3_12:
     if: ${{ inputs.macos && inputs.python_3_12 }}
@@ -243,7 +253,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
 
   unittests_check_linux:
     name: unittests-linux-${{ matrix.python.interpreter }}
@@ -271,7 +281,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_8:
@@ -291,7 +301,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_9:
@@ -311,7 +321,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_12:
@@ -331,7 +341,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features }}
           cargo fmt --all -- --check
 
   doctest_check:
@@ -347,7 +357,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           default: true
       - run: |
-          cargo test --doc --package=${{inputs.rust_package_name}}
+          cargo test --doc --package=${{inputs.rust_package_name}} --features ${{ inputs.features }}
 
   code_coverage_roqoqo:
     if: ${{inputs.test_code_coverage}}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -81,6 +81,8 @@ on:
         description: "Additional features to be enabled for the Rust package"
         required: false
         type: string
+env:
+  DEFAULT_FEATURES_VALUE: ${{ github.events.inputs.features || '' }}
 
 jobs:
   unittests_check_windows:
@@ -109,7 +111,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -38,9 +38,8 @@ on:
         default: true
         type: boolean
       features:
-        description: "Additional features to be enabled for the Rust package"
+        description: "Additional features to be enabled for the Rust package separated with commas"
         required: false
-        # default: ""
         type: string
   workflow_call:
     inputs:
@@ -79,12 +78,9 @@ on:
         default: true
         type: boolean
       features:
-        description: "Additional features to be enabled for the Rust package"
+        description: "Additional features to be enabled for the Rust package separated with commas"
         required: false
-        # default: ""
         type: string
-# env:
-#   DEFAULT_FEATURES_VALUE: "${{ inputs.features || 'json_schema' }}"
 
 jobs:
   unittests_check_windows:

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -83,8 +83,8 @@ on:
         required: false
         # default: ""
         type: string
-# env:
-#   DEFAULT_FEATURES_VALUE: ${{ inputs.features || 'json_schema' }}
+env:
+  DEFAULT_FEATURES_VALUE: "${{ inputs.features || 'json_schema' }}"
 
 jobs:
   unittests_check_windows:
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -132,7 +132,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_windows_py3_9:
     if: ${{ inputs.windows && inputs.python_3_9 }}
@@ -151,7 +151,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_windows_py3_12:
     if: ${{ inputs.windows && inputs.python_3_12 }}
@@ -170,7 +170,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_macos:
     if: ${{ inputs.macos }}
@@ -198,7 +198,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_macos_py3_8:
     if: ${{ inputs.macos && inputs.python_3_8 }}
@@ -217,7 +217,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_macos_py3_9:
     if: ${{ inputs.macos && inputs.python_3_9 }}
@@ -236,7 +236,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_macos_py3_12:
     if: ${{ inputs.macos && inputs.python_3_12 }}
@@ -255,7 +255,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_linux:
     name: unittests-linux-${{ matrix.python.interpreter }}
@@ -283,7 +283,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_8:
@@ -303,7 +303,7 @@ jobs:
           python-version: "3.8"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_9:
@@ -323,7 +323,7 @@ jobs:
           python-version: "3.9"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
   unittests_check_linux_py3_12:
@@ -343,7 +343,7 @@ jobs:
           python-version: "3.12"
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
   doctest_check:
@@ -359,7 +359,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           default: true
       - run: |
-          cargo test --doc --package=${{inputs.rust_package_name}} --features ${{ inputs.features || '' }}
+          cargo test --doc --package=${{inputs.rust_package_name}} --features "${{ inputs.features || '' }}"
 
   code_coverage_roqoqo:
     if: ${{inputs.test_code_coverage}}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features "${{ env.DEFAULT_FEATURES_VALUE || 'json_schema' }}"
+          cargo test --workspace --no-default-features --locked --features ""
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -40,7 +40,7 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
-        default: ""
+        # default: ""
         type: string
   workflow_call:
     inputs:
@@ -81,10 +81,10 @@ on:
       features:
         description: "Additional features to be enabled for the Rust package"
         required: false
-        default: ""
+        # default: ""
         type: string
-env:
-  DEFAULT_FEATURES_VALUE: ${{ inputs.features || 'json_schema' }}
+# env:
+#   DEFAULT_FEATURES_VALUE: ${{ inputs.features || 'json_schema' }}
 
 jobs:
   unittests_check_windows:
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features json_schema
+          cargo test --workspace --no-default-features --locked --features ${{ inputs.features || '' }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -82,7 +82,7 @@ on:
         required: false
         type: string
 env:
-  DEFAULT_FEATURES_VALUE: ${{ github.events.inputs.features || '' }}
+  DEFAULT_FEATURES_VALUE: ${{ github.events.inputs.features || ' ' }}
 
 jobs:
   unittests_check_windows:

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || 'json_schema' }}""
+          cargo test --workspace --no-default-features --locked --features "${{ inputs.features || 'json_schema' }}"
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -82,7 +82,7 @@ on:
         required: false
         type: string
 env:
-  DEFAULT_FEATURES_VALUE: ${{ github.events.inputs.features || ' ' }}
+  DEFAULT_FEATURES_VALUE: ${{ inputs.features || ' ' }}
 
 jobs:
   unittests_check_windows:

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -84,7 +84,7 @@ on:
         default: ""
         type: string
 env:
-  DEFAULT_FEATURES_VALUE: ${{ inputs.features || ' ' }}
+  DEFAULT_FEATURES_VALUE: ${{ inputs.features || 'json_schema' }}
 
 jobs:
   unittests_check_windows:

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ""
+          cargo test --workspace --no-default-features --locked --features "json_schema"
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -113,7 +113,7 @@ jobs:
           python-version: ${{ matrix.python.py }}
       - run: |
           python -m pip install numpy
-          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE }}
+          cargo test --workspace --no-default-features --locked --features ${{ env.DEFAULT_FEATURES_VALUE || 'json_schema' }}
 
   unittests_check_windows_py3_8:
     if: ${{ inputs.windows && inputs.python_3_8 }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -38,7 +38,7 @@ on:
         default: true
         type: boolean
       features:
-        description: "Additional features to be enabled for the Rust package separated with commas"
+        description: "Additional features to be enabled for the Rust package separated with commas or whitespaces"
         required: false
         type: string
   workflow_call:
@@ -78,7 +78,7 @@ on:
         default: true
         type: boolean
       features:
-        description: "Additional features to be enabled for the Rust package separated with commas"
+        description: "Additional features to be enabled for the Rust package separated with commas or whitespaces"
         required: false
         type: string
 


### PR DESCRIPTION
Adds support for testing features.
The package will have to add a `features` string as input, containing the names of the features that one wants to test separated by commas.
https://github.com/HQSquantumsimulations/qoqo/pull/586/files example here
```
  unittests:
    uses: mlodi-hqs/reusable_workflows/.github/workflows/reusable_unittests_rust_pyo3.yml@unittesting_features
    with:
      # Run tests also on windows runners
      windows: true
      # Run tests also on macos runners
      macos: true
      rust_package_name: "roqoqo"
      features: "json_schema overrotate unstable_chain_with_environment"
```