### PR TITLE
Python 3.13 Workflows

### DIFF
--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       py_interface_folder:
@@ -42,6 +47,11 @@ on:
         description: "Run unittest on Python 3.12"
         required: false
         default: true
+        type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
         type: boolean
 
 jobs:
@@ -115,6 +125,40 @@ jobs:
         run: |
           RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.12" --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target x86_64-apple-darwin
           RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.12" --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target aarch64-apple-darwin
+      - name: store artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos_wheels
+          path: wheels
+  
+  build_maturin_builds_macos_py313:
+    if: ${{ inputs.python_3_13 }}
+    name: maturin_build-macos-python3.13
+    runs-on: 'macOS-13'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: "aarch64-apple-darwin"
+          default: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip pytest numpy twine
+          python -m pip install maturin setuptools
+      - name: macos wheels
+        if: ${{ inputs.universal2 == false }}
+        run: |
+          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+      - name: universal wheels
+        if: ${{ inputs.universal2}}
+        run: |
+          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target x86_64-apple-darwin
+          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target aarch64-apple-darwin
       - name: store artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       py_interface_folder:
@@ -52,6 +57,11 @@ on:
         description: "Run unittest on Python 3.12"
         required: false
         default: true
+        type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
         type: boolean
 
 jobs:
@@ -101,6 +111,30 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install maturin pytest numpy setuptools
+          pip install ${{inputs.py_interface_folder}}/
+      - name: test
+        if: ${{inputs.has_python_tests}}
+        run: |
+          pytest ${{inputs.py_interface_folder}}/python_tests
+  
+  test_maturin_builds_linux_py313:
+    if: ${{ inputs.python_3_13 }}
+    name: maturin_check_linux-python3.13
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      # - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           pip install maturin pytest numpy setuptools
@@ -165,6 +199,30 @@ jobs:
         if: ${{inputs.has_python_tests}}
         run: |
           pytest ${{inputs.py_interface_folder}}/python_tests
+  
+  test_maturin_builds_windows_py313:
+    name: maturin_check_windows-python3.13
+    if: ${{ inputs.windows && inputs.python_3_13 }}
+    runs-on: "windows-latest"
+    steps:
+      - uses: actions/checkout@v3
+      # - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          pip install maturin pytest numpy setuptools
+          pip install ${{inputs.py_interface_folder}}/
+      - name: test
+        if: ${{inputs.has_python_tests}}
+        run: |
+          pytest ${{inputs.py_interface_folder}}/python_tests
 
   test_maturin_builds_macos:
     name: maturin_check_macos-${{ matrix.python.interpreter }}
@@ -215,6 +273,31 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install maturin pytest numpy setuptools
+          pip install ${{inputs.py_interface_folder}}/
+      - name: test
+        if: ${{inputs.has_python_tests}}
+        run: |
+          pytest ${{inputs.py_interface_folder}}/python_tests
+  
+  test_maturin_builds_macos_py313:
+    name: maturin_check_macos-python3.13
+    if: ${{ inputs.macos && inputs.python_3_13 }}
+    runs-on: "macOS-13"
+    steps:
+      - uses: actions/checkout@v3
+      # - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: "aarch64-apple-darwin"
+          default: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           pip install maturin pytest numpy setuptools

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: true
         type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       python_folder:
@@ -60,6 +65,11 @@ on:
         description: "Run unittest on Python 3.12"
         required: false
         default: true
+        type: boolean
+      python_3_13:
+        description: "Run unittest on Python 3.13"
+        required: false
+        default: false
         type: boolean
 
 jobs:
@@ -126,6 +136,30 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install setuptools
+          pip install ${{inputs.python_folder}}/[tests]
+      - name: Test with coverage pytest
+        if: ${{inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/ --cov=${{inputs.python_folder}} --cov-fail-under=80
+      - name: Test without coverage pytest
+        if: ${{!inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/
+
+  test_python_linux_py3_13:
+    name: test_python_linux-python3.13
+    if: ${{ inputs.python_3_13 }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           pip install setuptools
@@ -219,6 +253,30 @@ jobs:
           cd ${{inputs.python_folder}}
           pytest tests/
 
+  test_python_windows_py3_13:
+    name: test_python_windows-python3.13
+    if: ${{ inputs.python_3_13 }}
+    runs-on: "windows-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          pip install setuptools
+          pip install ${{inputs.python_folder}}/[tests]
+      - name: Test with coverage pytest
+        if: ${{inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/ --cov=${{inputs.python_folder}} --cov-fail-under=80
+      - name: Test without coverage pytest
+        if: ${{!inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/
+
   test_python_macos:
     name: test_python_macos-${{ matrix.python.interpreter }}
     runs-on: "macOS-13"
@@ -282,6 +340,30 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install setuptools
+          pip install ${{inputs.python_folder}}/[tests]
+      - name: Test with coverage pytest
+        if: ${{inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/ --cov=${{inputs.python_folder}} --cov-fail-under=80
+      - name: Test without coverage pytest
+        if: ${{!inputs.test_code_coverage}}
+        run: |
+          cd ${{inputs.python_folder}}
+          pytest tests/
+  
+  test_python_macos_py3_13:
+    name: test_python_macos-python3.13
+    if: ${{ inputs.python_3_13 }}
+    runs-on: "macOS-13"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           pip install setuptools


### PR DESCRIPTION
Adds support for Python 3.13.
For the moment the jobs default to false, meaning they have to be manually set from the caller in order for them to run.