### PR TITLE
`maturin-action` 3.13 Fix

### DIFF
--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -56,7 +56,7 @@ jobs:
           maturin-version: latest
           command: build
           manylinux: 2014
-          args: --find-interpreter --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
       - name: store artifact
         uses: actions/upload-artifact@v4
         with:
@@ -87,7 +87,7 @@ jobs:
           command: build
           manylinux: 2014
           target: aarch64-unknown-linux-gnu
-          args: --find-interpreter --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
       - name: store artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -25,7 +25,6 @@ on:
         type: boolean
 
 jobs:
-
   build_maturin_builds_windows:
     name: maturin_build-windows
     runs-on: 'windows-latest'
@@ -42,7 +41,7 @@ jobs:
         with:
           maturin-version: latest
           command: build
-          args: --find-interpreter --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
       - name: store artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
`PyO3/maturin-action@v1`'s containerized pythons has added 3.13, so the `--find-interpreter` flag will build a package for it by default. This breaks most packages because they are still on `0.21`.
This temporarily fixes the problem, I'll add a better, parametrized solution.