### PR TITLE
`arm64` + `setup-rust-toolchain@v1`

### DIFF
--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -191,7 +191,7 @@ jobs:
 
   deploy_arm:
     if: ${{ inputs.deploy && inputs.build_for_arm }}
-    needs: [maturin_build_linux_arm]
+    needs: maturin_build_linux_arm
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v5

--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Build Linux Wheels (py3.9-3.13)
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Build Linux Wheel (py3.13)
@@ -103,7 +103,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Build Linux Wheels (py3.9-3.13 arm)
@@ -128,7 +128,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Build Linux Wheel (py3.13 arm)
@@ -152,7 +152,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Build Linux Source Distribution
@@ -172,7 +172,7 @@ jobs:
     needs: [maturin_build_linux_src, maturin_build_linux]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: actions/download-artifact@v4
@@ -194,7 +194,7 @@ jobs:
     needs: [maturin_build_linux_arm]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: actions/download-artifact@v4

--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Build Linux Wheels (py3.9-3.13)
+      - name: Build Linux Wheels (py3.9-3.12)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Build Linux Wheels (py3.9-3.13 arm)
+      - name: Build Linux Wheels (py3.9-3.12 arm)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest

--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -8,17 +8,17 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
         required: false
         default: false
         type: boolean
       build_for_arm:
-        description: "Determines python wheels are also build for aarch64"
+        description: "Determines if python wheels should be built for aarch64"
         required: false
         default: false
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
@@ -29,160 +29,139 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
         required: false
         default: false
         type: boolean
       build_for_arm:
-        description: "Determines python wheels are also build for aarch64"
+        description: "Determines if python wheels should be built for aarch64"
         required: false
         default: false
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
 
 jobs:
-  build_maturin_builds_linux:
-    name: maturin_build-linux
+  maturin_build_linux:
+    name: maturin_build_linux
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: linux wheels
+      - name: Build Linux Wheels (py3.9-3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
           args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux_wheels_p_3.9_3.10_3.11_3.12
           path: wheels
 
-  build_maturin_builds_linux_py313:
+  maturin_build_linux_py313:
     if: ${{ inputs.python_3_13 }}
-    name: maturin_build-linux-py313
+    name: maturin_build_linux_py313
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: linux wheels
+      - name: Build Linux Wheel (py3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
           args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.13
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux_wheels_p_3.13
           path: wheels
 
-  build_maturin_builds_linux_arm:
-    name: maturin_build-linux-arm
+  maturin_build_linux_arm:
+    name: maturin_build_linux_arm
     if: ${{ inputs.build_for_arm }}
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04-arm'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: linux wheels
+      - name: Build Linux Wheels (py3.9-3.13 arm)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          target: aarch64-unknown-linux-gnu
           args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux_arm_wheels_p_3.9_3.10_3.11_3.12
           path: wheels
   
-  build_maturin_builds_linux_arm_py313:
-    name: maturin_build-linux-arm-py313
+  maturin_build_linux_arm_py313:
+    name: maturin_build_linux_arm_py313
     if: ${{ inputs.build_for_arm && inputs.python_3_13 }}
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04-arm'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: linux wheels
+      - name: Build Linux Wheel (py3.13 arm)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          target: aarch64-unknown-linux-gnu
           args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.13
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux_arm_wheels_p_3.13
           path: wheels
 
-  build_maturin_src_builds_linux:
-    name: maturin_build-src
+  maturin_build_linux_src:
+    name: maturin_build_linux_src
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: linux wheels
+      - name: Build Linux Source Distribution
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: sdist
           args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux_sdist
@@ -190,7 +169,7 @@ jobs:
 
   deploy:
     if: ${{ inputs.deploy }}
-    needs: [build_maturin_src_builds_linux, build_maturin_builds_linux]
+    needs: [maturin_build_linux_src, maturin_build_linux]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v4
@@ -210,9 +189,9 @@ jobs:
         pip install twine
         python -m twine upload --skip-existing wheels/*
 
-  deploy-arm:
+  deploy_arm:
     if: ${{ inputs.deploy && inputs.build_for_arm }}
-    needs: [build_maturin_builds_linux_arm]
+    needs: [maturin_build_linux_arm]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v4

--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -8,17 +8,17 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
         required: false
         default: false
         type: boolean
       universal2:
-        description: "Build python wheels with universal2 flag"
+        description: "Determines if python wheels should be built with universal2 flag"
         required: false
         default: true
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
@@ -29,26 +29,25 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
         required: false
         default: false
         type: boolean
       universal2:
-        description: "Build python wheels with universal2 flag"
+        description: "Determines if python wheels should be built with universal2 flag"
         required: false
         default: true
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
 
 jobs:
-
-  build_maturin_builds_macos:
-    name: maturin_build-macos-${{ matrix.python.interpreter }}
-    runs-on: 'macOS-13'
+  maturin_build_macos:
+    name: maturin_build_macos_${{ matrix.python.interpreter }}
+    runs-on: 'macos-13'
     strategy:
       matrix:
         python: [
@@ -59,80 +58,138 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          target: "aarch64-apple-darwin"
-          default: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pytest numpy twine
           python -m pip install maturin
-      - name: macos wheels
-        if: ${{ inputs.universal2 == false }}
-        run: |
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
-      - name: universal wheels
-        if: ${{ inputs.universal2 }}
-        run: |
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target x86_64-apple-darwin
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target aarch64-apple-darwin
-      - name: store artifact
+      - name: Set RUSTFLAGS
+        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos_wheels_p_${{ matrix.python.py }}
           path: wheels
   
-  build_maturin_builds_macos_py313:
+  maturin_build_macos_py313:
     if: ${{ inputs.python_3_13 }}
-    name: maturin_build-macos-python3.13
-    runs-on: 'macOS-13'
+    name: maturin_build_macos_py313
+    runs-on: 'macos-13'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          target: "aarch64-apple-darwin"
-          default: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip pytest numpy twine
           python -m pip install maturin setuptools
-      - name: macos wheels
-        if: ${{ inputs.universal2 == false }}
-        run: |
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
-      - name: universal wheels
-        if: ${{ inputs.universal2 }}
-        run: |
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked --target x86_64-apple-darwin
-          RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked --target aarch64-apple-darwin
-      - name: store artifact
+      - name: Set RUSTFLAGS
+        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos_wheels_p_3.13
           path: wheels
+  
+  maturin_build_macos_arm:
+    name: maturin_build_macos_arm${{ matrix.python.interpreter }}
+    if: ${{ inputs.universal2 }}
+    runs-on: 'macos-latest'
+    strategy:
+      matrix:
+        python: [
+            { py: '3.9', interpreter: "python3.9" },
+            { py: '3.10', interpreter: "python3.10" },
+            { py: '3.11', interpreter: "python3.11" },
+            { py: '3.12', interpreter: "python3.12" },
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python.py }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip pytest numpy twine
+          python -m pip install maturin
+      - name: Set RUSTFLAGS
+        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+      - name: Store Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos_arm_wheels_p_${{ matrix.python.py }}
+          path: wheels
+  
+  maturin_build_macos_arm_py313:
+    if: ${{ inputs.universal2 && inputs.python_3_13}}
+    name: maturin_build_macos_arm_py313
+    runs-on: 'macos-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip pytest numpy twine
+          python -m pip install maturin setuptools
+      - name: Set RUSTFLAGS
+        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
+      - name: Store Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos_arm_wheels_p_3.13
+          path: wheels
 
   deploy:
     if: ${{ inputs.deploy }}
-    needs: build_maturin_builds_macos
+    needs: maturin_build_macos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: actions/download-artifact@v4
       with:
         path: wheels
         pattern: macos_wheels_p*
+        merge-multiple: true        
+    - name: Publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+        python -m twine upload --skip-existing wheels/*
+  
+  deploy_arm:
+    if: ${{ inputs.deploy && inputs.universal2 }}
+    needs: maturin_build_macos_arm
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - uses: actions/download-artifact@v4
+      with:
+        path: wheels
+        pattern: macos_arm_wheels_p*
         merge-multiple: true        
     - name: Publish
       env:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -98,16 +98,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Build Windows Wheels (py3.11-3.12)
+      - name: Build Windows Wheels (py3.12)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.11 python3.12
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.12
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows_arm_wheels_p_3.11_3.12
+          name: windows_arm_wheels_p_3.12
           path: wheels
   
   maturin_build_windows_arm_py313:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -98,16 +98,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Build Windows Wheels (py3.9-3.12)
+      - name: Build Windows Wheels (py3.11-3.12)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.11 python3.12
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows_arm_wheels_p_3.10_3.11_3.12
+          name: windows_arm_wheels_p_3.11_3.12
           path: wheels
   
   maturin_build_windows_arm_py313:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -12,11 +12,11 @@ on:
         required: false
         default: false
         type: boolean
-      build_for_arm:
-        description: "Determines if python wheels should be built for aarch64"
-        required: false
-        default: false
-        type: boolean
+      # build_for_arm:
+      #   description: "Determines if python wheels should be built for aarch64"
+      #   required: false
+      #   default: false
+      #   type: boolean
       python_3_13:
         description: "Determines if python wheels should be built for Python 3.13"
         required: false
@@ -33,11 +33,11 @@ on:
         required: false
         default: false
         type: boolean
-      build_for_arm:
-        description: "Determines if python wheels should be built for aarch64"
-        required: false
-        default: false
-        type: boolean
+      # build_for_arm:
+      #   description: "Determines if python wheels should be built for aarch64"
+      #   required: false
+      #   default: false
+      #   type: boolean
       python_3_13:
         description: "Determines if python wheels should be built for Python 3.13"
         required: false
@@ -89,53 +89,53 @@ jobs:
           name: windows_wheels_p_3.13
           path: wheels
 
-  maturin_build_windows_arm:
-    if: ${{ inputs.build_for_arm }}
-    name: maturin_build_windows_arm
-    runs-on: 'windows-11-arm'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Build Windows Wheels (py3.12)
-        uses: PyO3/maturin-action@v1
-        with:
-          maturin-version: latest
-          command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.12
-      - name: Store Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows_arm_wheels_p_3.12
-          path: wheels
+  # maturin_build_windows_arm:
+  #   if: ${{ inputs.build_for_arm }}
+  #   name: maturin_build_windows_arm
+  #   runs-on: 'windows-11-arm'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions-rust-lang/setup-rust-toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.12"
+  #     - name: Build Windows Wheels (py3.12)
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         maturin-version: latest
+  #         command: build
+  #         args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.12
+  #     - name: Store Artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: windows_arm_wheels_p_3.12
+  #         path: wheels
   
-  maturin_build_windows_arm_py313:
-    if: ${{ inputs.python_3_13 && inputs.build_for_arm }}
-    name: maturin_build_windows_arm_py313
-    runs-on: 'windows-11-arm'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Build Windows Wheel (py3.13)
-        uses: PyO3/maturin-action@v1
-        with:
-          maturin-version: latest
-          command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
-      - name: Store Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows_arm_wheels_p_3.13
-          path: wheels
+  # maturin_build_windows_arm_py313:
+  #   if: ${{ inputs.python_3_13 && inputs.build_for_arm }}
+  #   name: maturin_build_windows_arm_py313
+  #   runs-on: 'windows-11-arm'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions-rust-lang/setup-rust-toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.13"
+  #     - name: Build Windows Wheel (py3.13)
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         maturin-version: latest
+  #         command: build
+  #         args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
+  #     - name: Store Artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: windows_arm_wheels_p_3.13
+  #         path: wheels
 
   deploy:
     if: ${{ inputs.deploy }}
@@ -159,24 +159,24 @@ jobs:
         pip install twine
         python -m twine upload --skip-existing wheels/*
 
-  deploy_arm:
-    if: ${{ inputs.deploy && inputs.build_for_arm }}
-    needs: [maturin_build_windows_arm]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - uses: actions/download-artifact@v4
-      with:
-        path: wheels
-        pattern: windows_arm_wheels_p*
-        merge-multiple: true  
-    - name: Publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install twine
-        python -m twine upload --skip-existing wheels/*
+  # deploy_arm:
+  #   if: ${{ inputs.deploy && inputs.build_for_arm }}
+  #   needs: [maturin_build_windows_arm]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: "3.12"
+  #   - uses: actions/download-artifact@v4
+  #     with:
+  #       path: wheels
+  #       pattern: windows_arm_wheels_p*
+  #       merge-multiple: true  
+  #   - name: Publish
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install twine
+  #       python -m twine upload --skip-existing wheels/*

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Build Windows Wheels (py3.9-3.13)
+      - name: Build Windows Wheels (py3.9-3.12)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
@@ -98,16 +98,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Build Windows Wheels (py3.9-3.13)
+      - name: Build Windows Wheels (py3.9-3.12)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows_arm_wheels_p_3.9_3.10_3.11_3.12
+          name: windows_arm_wheels_p_3.10_3.11_3.12
           path: wheels
   
   maturin_build_windows_arm_py313:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -8,12 +8,17 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
+        required: false
+        default: false
+        type: boolean
+      build_for_arm:
+        description: "Determines if python wheels should be built for aarch64"
         required: false
         default: false
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
@@ -24,70 +29,114 @@ on:
         required: true
         type: string
       deploy:
-        description: "Determines if build python wheels should be deployed to PyPi"
+        description: "Determines if built python wheels should be deployed to PyPi"
+        required: false
+        default: false
+        type: boolean
+      build_for_arm:
+        description: "Determines if python wheels should be built for aarch64"
         required: false
         default: false
         type: boolean
       python_3_13:
-        description: "Build for Python 3.13"
+        description: "Determines if python wheels should be built for Python 3.13"
         required: false
         default: true
         type: boolean
 
 jobs:
-  build_maturin_builds_windows:
-    name: maturin_build-windows
+  maturin_build_windows:
+    name: maturin_build_windows
     runs-on: 'windows-latest'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
-      - name: windows wheels
+      - name: Build Windows Wheels (py3.9-3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows_wheels_p_3.9_3.10_3.11_3.12
           path: wheels
   
-  build_maturin_builds_windows_py313:
+  maturin_build_windows_py313:
     if: ${{ inputs.python_3_13 }}
-    name: maturin_build-windows-py313
+    name: maturin_build_windows_py313
     runs-on: 'windows-2025'
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: windows wheels
+      - name: Build Windows Wheel (py3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
-      - name: store artifact
+      - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows_wheels_p_3.13
           path: wheels
 
+  maturin_build_windows_arm:
+    if: ${{ inputs.build_for_arm }}
+    name: maturin_build_windows_arm
+    runs-on: 'windows-11-arm'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build Windows Wheels (py3.9-3.13)
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: latest
+          command: build
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.9 python3.10 python3.11 python3.12
+      - name: Store Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows_arm_wheels_p_3.9_3.10_3.11_3.12
+          path: wheels
+  
+  maturin_build_windows_arm_py313:
+    if: ${{ inputs.python_3_13 && inputs.build_for_arm }}
+    name: maturin_build_windows_arm_py313
+    runs-on: 'windows-11-arm'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Build Windows Wheel (py3.13)
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: latest
+          command: build
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
+      - name: Store Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows_arm_wheels_p_3.13
+          path: wheels
+
   deploy:
     if: ${{ inputs.deploy }}
-    needs: build_maturin_builds_windows
+    needs: maturin_build_windows
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v4
@@ -97,6 +146,28 @@ jobs:
       with:
         path: wheels
         pattern: windows_wheels_p*
+        merge-multiple: true  
+    - name: Publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+        python -m twine upload --skip-existing wheels/*
+
+  deploy_arm:
+    if: ${{ inputs.deploy && inputs.build_for_arm }}
+    needs: [maturin_build_windows_arm]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+    - uses: actions/download-artifact@v4
+      with:
+        path: wheels
+        pattern: windows_arm_wheels_p*
         merge-multiple: true  
     - name: Publish
       env:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -139,7 +139,7 @@ jobs:
     needs: maturin_build_windows
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: actions/download-artifact@v4
@@ -161,7 +161,7 @@ jobs:
     needs: [maturin_build_windows_arm]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: actions/download-artifact@v4

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -98,6 +98,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Build Windows Wheels (py3.12)
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/reusable_build_pure_python.yml
+++ b/.github/workflows/reusable_build_pure_python.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install dependencies

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install Dependencies
@@ -94,7 +94,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
       - name: Install Dependencies
@@ -125,7 +125,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python.py }}'
       - name: Install Dependencies
@@ -148,7 +148,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
       - name: Install Dependencies
@@ -204,7 +204,7 @@ jobs:
         with:
           toolchain: stable
           target: "aarch64-apple-darwin"
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
       - name: Install Dependencies

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -75,15 +75,12 @@ jobs:
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install Dependencies
-        run: |
-          pip install maturin pytest numpy
+        run: pip install maturin pytest numpy
       - name: Build Test
-        run: |
-          pip install ${{ inputs.py_interface_folder }}/
+        run: pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
   build_test_linux_py313:
     if: ${{ inputs.python_3_13 }}
@@ -98,15 +95,12 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install Dependencies
-        run: |
-          pip install maturin pytest numpy setuptools
+        run: pip install maturin pytest numpy setuptools
       - name: Build Test
-        run: |
-          pip install ${{ inputs.py_interface_folder }}/
+        run: pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests
 
   build_test_windows:
     name: build_test_windows_${{ matrix.python.interpreter }}
@@ -129,15 +123,12 @@ jobs:
         with:
           python-version: '${{ matrix.python.py }}'
       - name: Install Dependencies
-        run: |
-          pip install maturin pytest numpy
+        run: pip install maturin pytest numpy
       - name: Build Test
-        run: |
-          pip install ${{ inputs.py_interface_folder }}/
+        run: pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
   build_test_windows_py313:
     name: build_test_windows_py313
@@ -152,15 +143,12 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install Dependencies
-        run: |
-          pip install maturin pytest numpy setuptools
+        run: pip install maturin pytest numpy setuptools
       - name: Build Test
-        run: |
-          pip install ${{ inputs.py_interface_folder }}/
+        run: pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests
 
   build_test_macos:
     name: build_test_macos${{ matrix.python.interpreter }}
@@ -184,15 +172,12 @@ jobs:
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install Dependencies
-        run: |
-          python -m pip install maturin pytest numpy
+        run: python -m pip install maturin pytest numpy
       - name: Build Test
-        run: |
-          python -m pip install ${{ inputs.py_interface_folder }}/
+        run: python -m pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
   build_test_macos_py313:
     name: build_test_macos_py313
@@ -208,12 +193,9 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install Dependencies
-        run: |
-          pip install maturin pytest numpy setuptools
+        run: pip install maturin pytest numpy setuptools
       - name: Build Test
-        run: |
-          pip install ${{ inputs.py_interface_folder }}/
+        run: pip install ${{ inputs.py_interface_folder }}/
       - name: Test pytest
         if: ${{ inputs.has_python_tests }}
-        run: |
-          pytest ${{ inputs.py_interface_folder }}/python_tests
+        run: pytest ${{ inputs.py_interface_folder }}/python_tests

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -55,8 +55,8 @@ on:
         type: boolean
 
 jobs:
-  test_maturin_builds_linux:
-    name: maturin_check_linux-${{ matrix.python.interpreter }}
+  build_test_linux:
+    name: build_test_linux${{ matrix.python.interpreter }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -68,50 +68,48 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.py }}
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           pip install maturin pytest numpy
+      - name: Build Test
+        run: |
           pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  test_maturin_builds_linux_py313:
+  build_test_linux_py313:
     if: ${{ inputs.python_3_13 }}
-    name: maturin_check_linux-python3.13
+    name: build_test_linux_py313
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.13'
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           pip install maturin pytest numpy setuptools
+      - name: Build Test
+        run: |
           pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests
 
-  test_maturin_builds_windows:
-    name: maturin_check_windows-${{ matrix.python.interpreter }}
+  build_test_windows:
+    name: build_test_windows_${{ matrix.python.interpreter }}
     if: ${{ inputs.windows }}
     runs-on: "windows-latest"
     strategy:
@@ -124,50 +122,48 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '${{ matrix.python.py }}'
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           pip install maturin pytest numpy
+      - name: Build Test
+        run: |
           pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  test_maturin_builds_windows_py313:
-    name: maturin_check_windows-python3.13
+  build_test_windows_py313:
+    name: build_test_windows_py313
     if: ${{ inputs.windows && inputs.python_3_13 }}
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.13'
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           pip install maturin pytest numpy setuptools
+      - name: Build Test
+        run: |
           pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests
 
-  test_maturin_builds_macos:
-    name: maturin_check_macos-${{ matrix.python.interpreter }}
+  build_test_macos:
+    name: build_test_macos${{ matrix.python.interpreter }}
     if: ${{ inputs.macos }}
     runs-on: "macOS-13"
     strategy:
@@ -180,46 +176,44 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           target: "aarch64-apple-darwin"
-          default: true
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           python -m pip install maturin pytest numpy
+      - name: Build Test
+        run: |
           python -m pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  test_maturin_builds_macos_py313:
-    name: maturin_check_macos-python3.13
+  build_test_macos_py313:
+    name: build_test_macos_py313
     if: ${{ inputs.macos && inputs.python_3_13 }}
     runs-on: "macOS-13"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           target: "aarch64-apple-darwin"
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3.13'
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           pip install maturin pytest numpy setuptools
+      - name: Build Test
+        run: |
           pip install ${{ inputs.py_interface_folder }}/
-      - name: test
+      - name: Test pytest
         if: ${{ inputs.has_python_tests }}
         run: |
           pytest ${{ inputs.py_interface_folder }}/python_tests

--- a/.github/workflows/reusable_linting_pure_python.yml
+++ b/.github/workflows/reusable_linting_pure_python.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install Dependencies

--- a/.github/workflows/reusable_linting_pure_python.yml
+++ b/.github/workflows/reusable_linting_pure_python.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install Dependencies
-        run: |
-          pip install ${{ inputs.python_folder }}/[dev]
+        run: pip install ${{ inputs.python_folder }}/[dev]
       - name: Check - ruff
         run: |
           cd ${{ inputs.python_folder }}/

--- a/.github/workflows/reusable_linting_pure_python.yml
+++ b/.github/workflows/reusable_linting_pure_python.yml
@@ -23,26 +23,26 @@ on:
         type: string
 
 jobs:
-  test_python_linting_linux:
-    name: python_check_linting_linux
+  check_python_linting:
+    name: check_python_linting
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
-      - name: Install dependencies
+          python-version: "3.12"
+      - name: Install Dependencies
         run: |
           pip install ${{ inputs.python_folder }}/[dev]
-      - name: Lint with ruff
+      - name: Check - ruff
         run: |
           cd ${{ inputs.python_folder }}/
           ruff check ${{ inputs.linting_folder }}
-      - name: Mypy check
+      - name: Check - mypy
         run: |
           cd ${{ inputs.python_folder }}/
           mypy ${{ inputs.linting_folder }}
-      - name: Black formatting check
+      - name: Check - black
         run: |
           cd ${{ inputs.python_folder }}/
           black --check ${{ inputs.linting_folder }}

--- a/.github/workflows/reusable_linting_rust_pyo3.yml
+++ b/.github/workflows/reusable_linting_rust_pyo3.yml
@@ -13,8 +13,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - run: |
-          cargo clippy -- -D warnings
+      - run: cargo clippy -- -D warnings
 
   cargo_deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_linting_rust_pyo3.yml
+++ b/.github/workflows/reusable_linting_rust_pyo3.yml
@@ -5,20 +5,18 @@ on:
   workflow_call:
 
 jobs:
-  clippy_check:
+  clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: clippy
-      # - uses: Swatinem/rust-cache@v2
       - run: |
           cargo clippy -- -D warnings
 
-  cargo-deny:
+  cargo_deny:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
@@ -29,17 +29,17 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin
         pip install ${{ inputs.python_folder }}/[docs]
-    - name: build
+    - name: Build Documentation
       run: |
         cd ${{ inputs.docs_folder }}
         python -m sphinx -T -E -b html . _build/html
         cd ../../
-    - name: publish
+    - name: Publish
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Install dependencies

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -27,25 +27,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    # - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: stable
-        default: true
-    - name: Install dependencies
+    - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip maturin
         pip install ${{ inputs.py_interface_folder }}/[docs]
-    - name: build
+    - name: Build Documentation
       run: |
         cd ${{ inputs.py_docs_folder }}
         python -m sphinx -T -E -b html . _build/html
         cd ../../
-    - name: publish
+    - name: Publish
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -66,7 +66,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install dependencies
@@ -121,7 +121,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
@@ -144,7 +144,7 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install dependencies
@@ -176,7 +176,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
@@ -199,7 +199,7 @@ jobs:
     runs-on: "macOS-13"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install dependencies

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -72,19 +72,19 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/
 
-  test_python_linux_py3_13:
-    name: test_python_linux-python3.13
+  test_python_linux_py313:
+    name: test_python_linux_py313
     if: ${{ inputs.python_3_13 }}
     runs-on: "ubuntu-latest"
     steps:
@@ -96,12 +96,12 @@ jobs:
         run: |
           pip install setuptools
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
@@ -109,7 +109,7 @@ jobs:
 
   test_python_windows:
     if: ${{ inputs.windows }}
-    name: test_python_windows-${{ matrix.python.interpreter }}
+    name: test_python_windows_${{ matrix.python.interpreter }}
     runs-on: "windows-latest"
     strategy:
       matrix:
@@ -127,20 +127,20 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/
 
-  test_python_windows_py3_13:
+  test_python_windows_py313:
     if: ${{ inputs.windows && inputs.python_3_13 }}
-    name: test_python_windows-python3.13
+    name: test_python_windows_py313
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
@@ -151,12 +151,12 @@ jobs:
         run: |
           pip install setuptools
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
@@ -164,7 +164,7 @@ jobs:
 
   test_python_macos:
     if: ${{ inputs.macos }}
-    name: test_python_macos-${{ matrix.python.interpreter }}
+    name: test_python_macos_${{ matrix.python.interpreter }}
     runs-on: "macOS-13"
     strategy:
       matrix:
@@ -182,12 +182,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
@@ -195,7 +195,7 @@ jobs:
   
   test_python_macos_py3_13:
     if: ${{ inputs.macos && inputs.python_3_13 }}
-    name: test_python_macos-python3.13
+    name: test_python_macos_py313
     runs-on: "macOS-13"
     steps:
       - uses: actions/checkout@v3
@@ -206,12 +206,12 @@ jobs:
         run: |
           pip install setuptools
           pip install ${{ inputs.python_folder }}/[tests]
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}
           pytest tests/ --cov=${{ inputs.python_folder }} --cov-fail-under=80
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.test_code_coverage }}
         run: |
           cd ${{ inputs.python_folder }}

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -70,8 +70,7 @@ jobs:
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
-        run: |
-          pip install ${{ inputs.python_folder }}/[tests]
+        run: pip install ${{ inputs.python_folder }}/[tests]
       - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
@@ -125,8 +124,7 @@ jobs:
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
-        run: |
-          pip install ${{ inputs.python_folder }}/[tests]
+        run: pip install ${{ inputs.python_folder }}/[tests]
       - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |
@@ -180,8 +178,7 @@ jobs:
         with:
           python-version: ${{ matrix.python.py }}
       - name: Install dependencies
-        run: |
-          pip install ${{ inputs.python_folder }}/[tests]
+        run: pip install ${{ inputs.python_folder }}/[tests]
       - name: Test with Coverage pytest
         if: ${{ inputs.test_code_coverage }}
         run: |

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -212,12 +212,10 @@ jobs:
           target: x86_64-unknown-linux-gnu
       - name: Test with Coverage pytest
         if: ${{ inputs.rust_doc_package_name }}
-        run: |
-          cargo test --doc --package=${{ inputs.rust_doc_package_name }} --features "${{ inputs.features || '' }}"
+        run: cargo test --doc --package=${{ inputs.rust_doc_package_name }} --features "${{ inputs.features || '' }}"
       - name: Test without Coverage pytest
         if: ${{ !inputs.rust_doc_package_name }}
-        run: |
-          cargo test --doc --package=${{ inputs.rust_package_name }} --features "${{ inputs.features || '' }}"
+        run: cargo test --doc --package=${{ inputs.rust_package_name }} --features "${{ inputs.features || '' }}"
 
   code_coverage_roqoqo:
     if: ${{ inputs.test_code_coverage }}

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -77,7 +77,7 @@ on:
 jobs:
   unittests_check_windows:
     if: ${{ inputs.windows }}
-    name: unittests-windows-${{ matrix.python.interpreter }}
+    name: unittests_check_windows_${{ matrix.python.interpreter }}
     runs-on: "windows-latest"
     strategy:
       matrix:
@@ -90,12 +90,9 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.py }}
@@ -103,18 +100,15 @@ jobs:
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
-  unittests_check_windows_py3_13:
+  unittests_check_windows_py313:
     if: ${{ inputs.windows && inputs.python_3_13 }}
-    name: unittests-windows-python3.13
+    name: unittests_check_windows_py313
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: "3.13"
@@ -124,7 +118,7 @@ jobs:
 
   unittests_check_macos:
     if: ${{ inputs.macos }}
-    name: unittests-macos-${{ matrix.python.interpreter }}
+    name: unittests_check_macos_${{ matrix.python.interpreter }}
     runs-on: "macOS-13"
     strategy:
       matrix:
@@ -137,12 +131,9 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.py }}
@@ -150,18 +141,15 @@ jobs:
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
-  unittests_check_macos_py3_13:
+  unittests_check_macos_py313:
     if: ${{ inputs.macos && inputs.python_3_13 }}
-    name: unittests-macos-python3.13
+    name: unittests_check_macos_py313
     runs-on: "macOS-13"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: actions/setup-python@v4
         with:
           python-version: "3.13"
@@ -170,7 +158,7 @@ jobs:
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
   unittests_check_linux:
-    name: unittests-linux-${{ matrix.python.interpreter }}
+    name: unittests_check_linux_${{ matrix.python.interpreter }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -183,12 +171,9 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
           components: rustfmt
       - uses: actions/setup-python@v4
         with:
@@ -198,18 +183,15 @@ jobs:
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
-  unittests_check_linux_py3_13:
+  unittests_check_linux_py313:
     if: ${{ inputs.python_3_13 }}
-    name: unittests-linux-python3.13
+    name: unittests_check_linux_py313
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          default: true
           components: rustfmt
       - uses: actions/setup-python@v4
         with:
@@ -219,23 +201,20 @@ jobs:
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
-  doctest_check:
-    name: unittests_check-ubuntu-latest
+  check_doctest:
+    name: check_doctest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           target: x86_64-unknown-linux-gnu
-          default: true
-      - name: Test with coverage pytest
+      - name: Test with Coverage pytest
         if: ${{ inputs.rust_doc_package_name }}
         run: |
           cargo test --doc --package=${{ inputs.rust_doc_package_name }} --features "${{ inputs.features || '' }}"
-      - name: Test without coverage pytest
+      - name: Test without Coverage pytest
         if: ${{ !inputs.rust_doc_package_name }}
         run: |
           cargo test --doc --package=${{ inputs.rust_package_name }} --features "${{ inputs.features || '' }}"
@@ -245,10 +224,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: llvm-tools-preview
           override: true

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - run: |
@@ -109,7 +109,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - run: |
@@ -134,7 +134,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - run: |
@@ -150,7 +150,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - run: |
@@ -175,7 +175,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.py }}
       - run: |
@@ -193,7 +193,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - run: |


### PR DESCRIPTION
Changes:
- Deprecated the usage of `actions-rs/toolchain@v1` in favor of `actions-rust-lang/setup-rust-toolchain@v1`
- Simplified jobs names/input descriptions
- Modified `arm64` Linux jobs into using native runners
- Modified `arm64` macos jobs into using native runners
- Added `arm64` Windows jobs + `build_for_arm` input (EDIT: Commented out for the moment)
- Removed (already commented-out) instances of `Swatinem/rust-cache@v2` as `actions-rust-lang/setup-rust-toolchain@v1` already makes use of it
- Upped `actions/setup-python@v4` to `actions/setup-python@v5`