### PR TITLE
Python 3.13 as Default - Preparing 3.14

### DIFF
--- a/.github/workflows/reusable_build_maturin_linux.yml
+++ b/.github/workflows/reusable_build_maturin_linux.yml
@@ -17,10 +17,10 @@ on:
         required: false
         default: false
         type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -38,10 +38,10 @@ on:
         required: false
         default: false
         type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -55,23 +55,23 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Build Linux Wheels (py3.10-3.12)
+          python-version: '3.13'
+      - name: Build Linux Wheels (py3.10-3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12 python3.13
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux_wheels_p_3.10_3.11_3.12
+          name: linux_wheels_p_3.10_3.11_3.12_3.13
           path: wheels
 
-  maturin_build_linux_py313:
-    if: ${{ inputs.python_3_13 }}
-    name: maturin_build_linux_py313
+  maturin_build_linux_py314:
+    if: ${{ inputs.python_3_14 }}
+    name: maturin_build_linux_py314
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
@@ -80,18 +80,18 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Build Linux Wheel (py3.13)
+          python-version: '3.14'
+      - name: Build Linux Wheel (py3.14)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.13
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.14
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux_wheels_p_3.13
+          name: linux_wheels_p_3.14
           path: wheels
 
   maturin_build_linux_arm:
@@ -105,23 +105,23 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Build Linux Wheels (py3.10-3.12 arm)
+          python-version: '3.13'
+      - name: Build Linux Wheels (py3.10-3.13 arm)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12 python3.13
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux_arm_wheels_p_3.10_3.11_3.12
+          name: linux_arm_wheels_p_3.10_3.11_3.12_3.13
           path: wheels
   
-  maturin_build_linux_arm_py313:
-    name: maturin_build_linux_arm_py313
-    if: ${{ inputs.build_for_arm && inputs.python_3_13 }}
+  maturin_build_linux_arm_py314:
+    name: maturin_build_linux_arm_py314
+    if: ${{ inputs.build_for_arm && inputs.python_3_14 }}
     runs-on: 'ubuntu-24.04-arm'
     steps:
       - uses: actions/checkout@v4
@@ -130,18 +130,18 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Build Linux Wheel (py3.13 arm)
+          python-version: '3.14'
+      - name: Build Linux Wheel (py3.14 arm)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
           manylinux: 2014
-          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.13
+          args: --out wheels -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked -i python3.14
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux_arm_wheels_p_3.13
+          name: linux_arm_wheels_p_3.14
           path: wheels
 
   maturin_build_linux_src:
@@ -154,7 +154,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Build Linux Source Distribution
         uses: PyO3/maturin-action@v1
         with:
@@ -174,7 +174,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - uses: actions/download-artifact@v4
       with:
         path: wheels
@@ -196,7 +196,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - uses: actions/download-artifact@v4
       with:
         path: wheels

--- a/.github/workflows/reusable_build_maturin_macos.yml
+++ b/.github/workflows/reusable_build_maturin_macos.yml
@@ -17,10 +17,10 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -38,22 +38,23 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
   maturin_build_macos:
     name: maturin_build_macos_${{ matrix.python.interpreter }}
-    runs-on: 'macos-13'
+    runs-on: 'macos-15'
     strategy:
       matrix:
         python: [
             { py: '3.10', interpreter: "python3.10" },
             { py: '3.11', interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.12" },
         ]
     steps:
       - uses: actions/checkout@v4
@@ -68,17 +69,23 @@ jobs:
           python -m pip install --upgrade pip pytest numpy twine
           python -m pip install maturin
       - name: Set RUSTFLAGS
-        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+        run: |
+          if [ "${{ inputs.universal2 }}" = "true" ]; then
+            RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" \
+            maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked --target universal2-apple-darwin
+          else
+            RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" \
+            maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos_wheels_p_${{ matrix.python.py }}
           path: wheels
   
-  maturin_build_macos_py313:
-    if: ${{ inputs.python_3_13 }}
-    name: maturin_build_macos_python3.13
-    runs-on: 'macos-13'
+  maturin_build_macos_py314:
+    if: ${{ inputs.python_3_14 }}
+    name: maturin_build_macos_python3.14
+    runs-on: 'macos-15'
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -86,72 +93,23 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip pytest numpy twine
           python -m pip install maturin setuptools
-      - name: Set RUSTFLAGS
-        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
-      - name: Store Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_wheels_p_3.13
-          path: wheels
-  
-  maturin_build_macos_arm:
-    name: maturin_build_macos_arm_${{ matrix.python.interpreter }}
-    if: ${{ inputs.universal2 }}
-    runs-on: 'macos-latest'
-    strategy:
-      matrix:
-        python: [
-            { py: '3.10', interpreter: "python3.10" },
-            { py: '3.11', interpreter: "python3.11" },
-            { py: '3.12', interpreter: "python3.12" },
-        ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python.py }}
-      - name: Install Dependencies
+      - name: Set RUSTFLAGS and Build
         run: |
-          python -m pip install --upgrade pip pytest numpy twine
-          python -m pip install maturin
-      - name: Set RUSTFLAGS
-        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i ${{ matrix.python.interpreter }} --out wheels  -m ${{inputs.py_interface_folder}}/Cargo.toml --release --locked
+          if [ "${{ inputs.universal2 }}" = "true" ]; then
+            RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" \
+            maturin build -i "python3.14" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked --target universal2-apple-darwin
+          else
+            RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" \
+            maturin build -i "python3.14" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos_arm_wheels_p_${{ matrix.python.py }}
-          path: wheels
-  
-  maturin_build_macos_arm_py313:
-    if: ${{ inputs.universal2 && inputs.python_3_13}}
-    name: maturin_build_macos_arm_python3.13
-    runs-on: 'macos-latest'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip pytest numpy twine
-          python -m pip install maturin setuptools
-      - name: Set RUSTFLAGS
-        run: RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" maturin build -i "python3.13" --out wheels  -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked
-      - name: Store Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_arm_wheels_p_3.13
+          name: macos_wheels_p_3.14
           path: wheels
 
   deploy:
@@ -161,33 +119,11 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - uses: actions/download-artifact@v4
       with:
         path: wheels
         pattern: macos_wheels_p*
-        merge-multiple: true        
-    - name: Publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        python -m pip install --upgrade pip
-        pip install twine
-        python -m twine upload --skip-existing wheels/*
-  
-  deploy_arm:
-    if: ${{ inputs.deploy && inputs.universal2 }}
-    needs: maturin_build_macos_arm
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - uses: actions/download-artifact@v4
-      with:
-        path: wheels
-        pattern: macos_arm_wheels_p*
         merge-multiple: true        
     - name: Publish
       env:

--- a/.github/workflows/reusable_build_maturin_windows.yml
+++ b/.github/workflows/reusable_build_maturin_windows.yml
@@ -12,15 +12,10 @@ on:
         required: false
         default: false
         type: boolean
-      # build_for_arm:
-      #   description: "Determines if python wheels should be built for aarch64"
-      #   required: false
-      #   default: false
-      #   type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -33,15 +28,10 @@ on:
         required: false
         default: false
         type: boolean
-      # build_for_arm:
-      #   description: "Determines if python wheels should be built for aarch64"
-      #   required: false
-      #   default: false
-      #   type: boolean
-      python_3_13:
-        description: "Determines if python wheels should be built for Python 3.13"
+      python_3_14:
+        description: "Determines if python wheels should be built for Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -53,22 +43,22 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Build Windows Wheels (py3.10-3.12)
+      - name: Build Windows Wheels (py3.10-3.13)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.10 python3.11 python3.12 python3.13
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows_wheels_p_3.10_3.11_3.12
+          name: windows_wheels_p_3.10_3.11_3.12_3.13
           path: wheels
   
-  maturin_build_windows_py313:
-    if: ${{ inputs.python_3_13 }}
-    name: maturin_build_windows_py313
-    runs-on: 'windows-2025'
+  maturin_build_windows_py314:
+    if: ${{ inputs.python_3_14 }}
+    name: maturin_build_windows_py314
+    runs-on: 'windows-latest'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -76,66 +66,18 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-      - name: Build Windows Wheel (py3.13)
+          python-version: "3.14"
+      - name: Build Windows Wheel (py3.14)
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
+          args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.14
       - name: Store Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows_wheels_p_3.13
+          name: windows_wheels_p_3.14
           path: wheels
-
-  # maturin_build_windows_arm:
-  #   if: ${{ inputs.build_for_arm }}
-  #   name: maturin_build_windows_arm
-  #   runs-on: 'windows-11-arm'
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions-rust-lang/setup-rust-toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.12"
-  #     - name: Build Windows Wheels (py3.12)
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         maturin-version: latest
-  #         command: build
-  #         args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.12
-  #     - name: Store Artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: windows_arm_wheels_p_3.12
-  #         path: wheels
-  
-  # maturin_build_windows_arm_py313:
-  #   if: ${{ inputs.python_3_13 && inputs.build_for_arm }}
-  #   name: maturin_build_windows_arm_py313
-  #   runs-on: 'windows-11-arm'
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions-rust-lang/setup-rust-toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.13"
-  #     - name: Build Windows Wheel (py3.13)
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         maturin-version: latest
-  #         command: build
-  #         args: --out wheels -m ${{ inputs.py_interface_folder }}/Cargo.toml --release --locked -i python3.13
-  #     - name: Store Artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: windows_arm_wheels_p_3.13
-  #         path: wheels
 
   deploy:
     if: ${{ inputs.deploy }}
@@ -144,7 +86,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - uses: actions/download-artifact@v4
       with:
         path: wheels
@@ -158,25 +100,3 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine
         python -m twine upload --skip-existing wheels/*
-
-  # deploy_arm:
-  #   if: ${{ inputs.deploy && inputs.build_for_arm }}
-  #   needs: [maturin_build_windows_arm]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: "3.12"
-  #   - uses: actions/download-artifact@v4
-  #     with:
-  #       path: wheels
-  #       pattern: windows_arm_wheels_p*
-  #       merge-multiple: true  
-  #   - name: Publish
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install twine
-  #       python -m twine upload --skip-existing wheels/*

--- a/.github/workflows/reusable_build_pure_python.yml
+++ b/.github/workflows/reusable_build_pure_python.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/reusable_build_tests_rust_pyo3.yml
+++ b/.github/workflows/reusable_build_tests_rust_pyo3.yml
@@ -22,10 +22,10 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -48,10 +48,10 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -64,6 +64,7 @@ jobs:
             { py: '3.10', interpreter: "python3.10" },
             { py: '3.11', interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
         ]
     steps:
       - uses: actions/checkout@v4
@@ -81,9 +82,9 @@ jobs:
         if: ${{ inputs.has_python_tests }}
         run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  build_test_linux_py313:
-    if: ${{ inputs.python_3_13 }}
-    name: build_test_linux_python3.13
+  build_test_linux_py314:
+    if: ${{ inputs.python_3_14 }}
+    name: build_test_linux_python3.14
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
@@ -92,7 +93,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install Dependencies
         run: pip install maturin pytest numpy setuptools
       - name: Build Test
@@ -111,6 +112,7 @@ jobs:
             { py: '3.10', interpreter: "python3.10" },
             { py: '3.11', interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
         ]
     steps:
       - uses: actions/checkout@v4
@@ -128,9 +130,9 @@ jobs:
         if: ${{ inputs.has_python_tests }}
         run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  build_test_windows_py313:
-    name: build_test_windows_python3.13
-    if: ${{ inputs.windows && inputs.python_3_13 }}
+  build_test_windows_py314:
+    name: build_test_windows_python3.14
+    if: ${{ inputs.windows && inputs.python_3_14 }}
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
@@ -139,7 +141,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install Dependencies
         run: pip install maturin pytest numpy setuptools
       - name: Build Test
@@ -151,13 +153,14 @@ jobs:
   build_test_macos:
     name: build_test_macos_${{ matrix.python.interpreter }}
     if: ${{ inputs.macos }}
-    runs-on: "macos-13"
+    runs-on: "macos-15"
     strategy:
       matrix:
         python: [
             { py: '3.10', interpreter: "python3.10" },
             { py: '3.11', interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
         ]
     steps:
       - uses: actions/checkout@v4
@@ -176,10 +179,10 @@ jobs:
         if: ${{ inputs.has_python_tests }}
         run: pytest ${{ inputs.py_interface_folder }}/python_tests
   
-  build_test_macos_py313:
-    name: build_test_macos_python3.13
-    if: ${{ inputs.macos && inputs.python_3_13 }}
-    runs-on: "macos-13"
+  build_test_macos_py314:
+    name: build_test_macos_python3.14
+    if: ${{ inputs.macos && inputs.python_3_14 }}
+    runs-on: "macos-15"
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -188,7 +191,7 @@ jobs:
           target: "aarch64-apple-darwin"
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install Dependencies
         run: pip install maturin pytest numpy
       - name: Build Test

--- a/.github/workflows/reusable_linting_pure_python.yml
+++ b/.github/workflows/reusable_linting_pure_python.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install Dependencies
         run: pip install ${{ inputs.python_folder }}/[dev]
       - name: Check - ruff

--- a/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_pure_python_sphinx.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip maturin

--- a/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
+++ b/.github/workflows/reusable_publish_documentation_rust_sphinx.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/reusable_tests_pure_python.yml
+++ b/.github/workflows/reusable_tests_pure_python.yml
@@ -21,10 +21,10 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_call:
     inputs:
@@ -46,10 +46,10 @@ on:
         required: false
         default: true
         type: boolean
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -62,6 +62,7 @@ jobs:
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -81,15 +82,15 @@ jobs:
           cd ${{ inputs.python_folder }}
           pytest tests/
 
-  test_python_linux_py313:
-    name: test_python_linux_python3.13
-    if: ${{ inputs.python_3_13 }}
+  test_python_linux_py314:
+    name: test_python_linux_python3.14
+    if: ${{ inputs.python_3_14 }}
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           pip install setuptools
@@ -115,6 +116,7 @@ jobs:
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -134,15 +136,15 @@ jobs:
           cd ${{ inputs.python_folder }}
           pytest tests/
 
-  test_python_windows_py313:
-    if: ${{ inputs.windows && inputs.python_3_13 }}
-    name: test_python_windows_python3.13
+  test_python_windows_py314:
+    if: ${{ inputs.windows && inputs.python_3_14 }}
+    name: test_python_windows_python3.14
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           pip install setuptools
@@ -161,13 +163,14 @@ jobs:
   test_python_macos:
     if: ${{ inputs.macos }}
     name: test_python_macos_${{ matrix.python.interpreter }}
-    runs-on: "macOS-13"
+    runs-on: "macOS-15"
     strategy:
       matrix:
         python: [
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: '3.12', interpreter: "python3.12" },
+            { py: '3.13', interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -187,15 +190,15 @@ jobs:
           cd ${{ inputs.python_folder }}
           pytest tests/
   
-  test_python_macos_py3_13:
-    if: ${{ inputs.macos && inputs.python_3_13 }}
-    name: test_python_macos_python3.13
-    runs-on: "macOS-13"
+  test_python_macos_py3_14:
+    if: ${{ inputs.macos && inputs.python_3_14 }}
+    name: test_python_macos_python3.14
+    runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           pip install setuptools

--- a/.github/workflows/reusable_unittests_rust_pyo3.yml
+++ b/.github/workflows/reusable_unittests_rust_pyo3.yml
@@ -26,10 +26,10 @@ on:
         description: "Name of the pure rust package to doctest"
         required: false
         type: string
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
       features:
         description: "Additional features to be enabled for the Rust package separated with commas or whitespaces"
@@ -60,10 +60,10 @@ on:
         description: "Name of the pure rust package to doctest"
         required: false
         type: string
-      python_3_13:
-        description: "Run unittest on Python 3.13"
+      python_3_14:
+        description: "Run unittest on Python 3.14"
         required: false
-        default: true
+        default: false
         type: boolean
       features:
         description: "Additional features to be enabled for the Rust package separated with commas or whitespaces"
@@ -86,6 +86,7 @@ jobs:
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: "3.12", interpreter: "python3.12" },
+            { py: "3.13", interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -99,9 +100,9 @@ jobs:
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
-  unittests_check_windows_py313:
-    if: ${{ inputs.windows && inputs.python_3_13 }}
-    name: unittests_check_windows_python3.13
+  unittests_check_windows_py314:
+    if: ${{ inputs.windows && inputs.python_3_14 }}
+    name: unittests_check_windows_python3.14
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
@@ -110,7 +111,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: |
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
@@ -118,7 +119,7 @@ jobs:
   unittests_check_macos:
     if: ${{ inputs.macos }}
     name: unittests_check_macos_${{ matrix.python.interpreter }}
-    runs-on: "macOS-13"
+    runs-on: "macOS-15"
     strategy:
       matrix:
         python:
@@ -126,6 +127,7 @@ jobs:
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: "3.12", interpreter: "python3.12" },
+            { py: "3.13", interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -139,10 +141,10 @@ jobs:
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
 
-  unittests_check_macos_py313:
-    if: ${{ inputs.macos && inputs.python_3_13 }}
-    name: unittests_check_macos_python3.13
-    runs-on: "macOS-13"
+  unittests_check_macos_py314:
+    if: ${{ inputs.macos && inputs.python_3_14 }}
+    name: unittests_check_macos_python3.14
+    runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -150,7 +152,7 @@ jobs:
           toolchain: stable
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: |
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
@@ -165,6 +167,7 @@ jobs:
             { py: "3.10", interpreter: "python3.10" },
             { py: "3.11", interpreter: "python3.11" },
             { py: "3.12", interpreter: "python3.12" },
+            { py: "3.13", interpreter: "python3.13" },
           ]
     steps:
       - uses: actions/checkout@v4
@@ -180,9 +183,9 @@ jobs:
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"
           cargo fmt --all -- --check
 
-  unittests_check_linux_py313:
-    if: ${{ inputs.python_3_13 }}
-    name: unittests_check_linux_python3.13
+  unittests_check_linux_py314:
+    if: ${{ inputs.python_3_14 }}
+    name: unittests_check_linux_python3.14
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
@@ -192,7 +195,7 @@ jobs:
           components: rustfmt
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: |
           python -m pip install ${{ inputs.pip_install || 'numpy' }}
           cargo test --workspace --no-default-features --locked --features "${{ inputs.features || '' }}"


### PR DESCRIPTION
- Python 3.13 wheels are built now by default
- Any job that needed a stable version of python for `setup-python` now uses 3.13 (not 3.12 or 3.11 anymore)
- Python 3.14 jobs are prepared, set as `false` for the moment (no release yet)
- Default `macos` runner is now `macos-15`
- `universal2` flag for `macos` now is correctly used (requires `maturin >= 1.0`)
- Removed the arm jobs for `macos`: now by arm wheels are built by default, the universal ones (intel + arm) are built according to the `universal2` flag.
- Removed commented Windows arm jobs.